### PR TITLE
Tweak scaling range

### DIFF
--- a/src/EventLoopBridge.php
+++ b/src/EventLoopBridge.php
@@ -25,8 +25,10 @@ use const WyriHaximus\Constants\Numeric\ZERO;
 final class EventLoopBridge
 {
     private const DEFAULT_SCALE_RANGE = [
-        0.1,
         0.01,
+        0.0075,
+        0.0050,
+        0.0025,
         0.001,
     ];
 


### PR DESCRIPTION
Tweak the scaling range to have smoother scaling and dropping the ten times a second option as it causes too much lagging.